### PR TITLE
feat: return metadata

### DIFF
--- a/packages/core/src/cache-container/cache-container-types.ts
+++ b/packages/core/src/cache-container/cache-container-types.ts
@@ -10,7 +10,7 @@ export type CachedItem<T = any> = {
 export type CachingOptions = {
     /** (Default: 60) Number of seconds to expire the cachte item */
     ttl: number
-    /** (Default: true) If true, expired cache entries will be deleted on touch. If false, entries will be deleted after the given ttl. */
+    /** (Default: true) If true, expired cache entries will be deleted on touch and returned anyway. If false, entries will be deleted after the given ttl. */
     isLazy: boolean
     /** (Default: false) If true, cache entry has no expiration. */
     isCachedForever: boolean

--- a/packages/core/src/decorator/cache-decorator.ts
+++ b/packages/core/src/decorator/cache-decorator.ts
@@ -72,7 +72,7 @@ export function Cache(
                     if (entry) {
                         debug(`Cache HIT ${cacheKey}`)
 
-                        return entry
+                        return entry.content
                     }
 
                     debug(`Cache MISS ${cacheKey}`)

--- a/packages/core/src/withCache.ts
+++ b/packages/core/src/withCache.ts
@@ -33,7 +33,7 @@ export const withCacheFactory = (container: CacheContainer) => {
             const cachedResponse = await container.getItem<Awaited<Result>>(key);
 
             if (cachedResponse) {
-                return cachedResponse;
+                return cachedResponse.content;
             }
 
             const result = await operation(...parameters);

--- a/packages/core/test/cache-container.test.ts
+++ b/packages/core/test/cache-container.test.ts
@@ -18,15 +18,27 @@ describe("CacheContainer", () => {
         await cache.setItem("test", data, { ttl: 10 })
         const entry = await cache.getItem<ITestType>("test")
 
-        expect(entry).toStrictEqual(data)
+        expect(entry?.content).toStrictEqual(data)
     })
 
-    it("Should return no item if cache expires instantly with isLazy", async () => {
+    it("Should return item if cache expires instantly with isLazy", async () => {
         const cache = new CacheContainer(new MemoryStorage())
 
-        await cache.setItem("test", data, { ttl: -1 })
+        await cache.setItem("test", data, { ttl: -1, isLazy: true })
         const entry = await cache.getItem<ITestType>("test")
-        expect(entry).toStrictEqual(undefined)
+        expect(entry?.content).toStrictEqual(data)
+    })
+
+    it("Should item if cache expired with isLazy", async () => {
+        const cache = new CacheContainer(new MemoryStorage())
+
+        await cache.setItem("test", data, { ttl: 1, isLazy: true })
+        await wait(2000)
+        const entry = await cache.getItem<ITestType>("test")
+        expect(entry?.content).toStrictEqual(data)
+
+        const entryAgain = await cache.getItem<ITestType>("test")
+        expect(entryAgain?.content).toStrictEqual(undefined)
     })
 
     it("Should not find cache item after ttl with isLazy disabled", async () => {
@@ -50,7 +62,7 @@ describe("CacheContainer", () => {
         await wait(10)
 
         const entry = await cache.getItem<ITestType>("test")
-        expect(entry).toStrictEqual(data)
+        expect(entry?.content).toStrictEqual(data)
     })
 })
 

--- a/packages/core/test/cache-decorator-all.test.ts
+++ b/packages/core/test/cache-decorator-all.test.ts
@@ -95,7 +95,7 @@ function testForCache(cache: CacheContainer) {
 
                 expect(data).toStrictEqual(users)
                 expect(
-                    await cache.getItem<string[]>("TestClass1:getUsers:[]")
+                    (await cache.getItem<string[]>("TestClass1:getUsers:[]"))?.content
                 ).toStrictEqual(data)
             })
 
@@ -106,7 +106,7 @@ function testForCache(cache: CacheContainer) {
 
                 expect(data).toStrictEqual(response)
                 expect(
-                    await cache.getItem<string[]>("TestClass1:getUsersPromise:[]")
+                    (await cache.getItem<string[]>("TestClass1:getUsersPromise:[]"))?.content
                 ).toStrictEqual(data)
             })
 
@@ -116,7 +116,7 @@ function testForCache(cache: CacheContainer) {
                 const users = await myClass.getUsers()
                 expect(data).toStrictEqual(users)
                 expect(
-                    await cache.getItem<string[]>("TestClass2:getUsers:[]")
+                    (await cache.getItem<string[]>("TestClass2:getUsers:[]"))?.content
                 ).toStrictEqual(data)
             })
 
@@ -126,7 +126,7 @@ function testForCache(cache: CacheContainer) {
                 const users = await myClass.getUsers()
 
                 expect(data).toStrictEqual(users)
-                expect(await cache.getItem<string[]>("getUsers")).toStrictEqual(
+                expect((await cache.getItem<string[]>("getUsers"))?.content).toStrictEqual(
                     data
                 )
             })
@@ -138,7 +138,7 @@ function testForCache(cache: CacheContainer) {
 
                 expect(data).toStrictEqual(response)
                 expect(
-                    await cache.getItem<string[]>("getUsersPromise")
+                   (await cache.getItem<string[]>("getUsersPromise"))?.content
                 ).toStrictEqual(data)
             })
 
@@ -148,7 +148,7 @@ function testForCache(cache: CacheContainer) {
                 await myClass.getUsersPromise().then(async (response) => {
                     expect(data).toStrictEqual(response)
                     expect(
-                        await cache.getItem<string[]>("getUsersPromise")
+                        (await cache.getItem<string[]>("getUsersPromise"))?.content
                     ).toStrictEqual(data)
                 })
             })

--- a/packages/storage-ioredis/src/basic.test.ts
+++ b/packages/storage-ioredis/src/basic.test.ts
@@ -53,20 +53,20 @@ describe("01-basic", () => {
 
         const data = await strategy.getItem("settings")
 
-        expect(data).toStrictEqual(raw)
+        expect(data?.content).toStrictEqual(raw)
     })
 
-    it("Should return undefined if set item is expired", async () => {
+    it("Should return undefined if set item is expired and not lazy", async () => {
         const raw = {
             username: "max123"
         }
 
-        await strategy.setItem("user", raw, { ttl: 0.1, isLazy: true })
+        await strategy.setItem("user", raw, { ttl: 0.1, isLazy: false })
 
         await sleep(200)
 
         const data = await strategy.getItem("user")
 
-        expect(data).toStrictEqual(undefined)
+        expect(data?.content).toStrictEqual(undefined)
     })
 })

--- a/packages/storage-ioredis/src/with-decorator.test.ts
+++ b/packages/storage-ioredis/src/with-decorator.test.ts
@@ -70,7 +70,7 @@ describe("02-with-decorator", () => {
 
         const usersAfter10ms = await testClassInstance.getUsers()
 
-        expect(getUsersFromBackend).toHaveBeenCalledTimes(2)
+        expect(getUsersFromBackend).toHaveBeenCalledTimes(1)
         expect(users).toStrictEqual(usersAfter10ms)
     })
 })

--- a/packages/storage-ioredis/src/withCacheFactory.test.ts
+++ b/packages/storage-ioredis/src/withCacheFactory.test.ts
@@ -51,6 +51,6 @@ describe("withCacheFactory", () => {
     const result = await wrappedFn({ a: "wrapped-hello", b: 555 });
     expect(result).toMatchInlineSnapshot(`"wrapped-hello-555"`);
     const data = await container.getItem("testingFunction:great:test");
-    expect(data).toMatchInlineSnapshot(`"wrapped-hello-555"`);
+    expect(data?.content).toMatchInlineSnapshot(`"wrapped-hello-555"`);
   });
 });

--- a/packages/storage-memory/package.json
+++ b/packages/storage-memory/package.json
@@ -34,9 +34,9 @@
   },
   "homepage": "https://github.com/boredland/node-ts-cache#readme",
   "peerDependencies": {
-    "@boredland/node-ts-cache": "^5.0.0"
+    "@boredland/node-ts-cache": "^5.0.1"
   },
   "devDependencies": {
-    "@boredland/node-ts-cache": "^5.0.0"
+    "@boredland/node-ts-cache": "^5.0.1"
   }
 }

--- a/packages/storage-memory/src/index.ts
+++ b/packages/storage-memory/src/index.ts
@@ -3,13 +3,13 @@ import type { CachedItem, IStorage } from "@boredland/node-ts-cache"
 export class MemoryStorage implements IStorage {
     private memCache: any = {}
 
-    constructor() {}
+    constructor() { }
 
     public async getItem(key: string): Promise<CachedItem | undefined> {
         return this.memCache[key]
     }
 
-    public async setItem(key: string, content: any): Promise<void> {
+    public async setItem(key: string, content: CachedItem | undefined): Promise<void> {
         this.memCache[key] = content
     }
 

--- a/packages/storage-memory/src/memory-storage.test.ts
+++ b/packages/storage-memory/src/memory-storage.test.ts
@@ -1,15 +1,17 @@
 import { Cache, CacheContainer } from "@boredland/node-ts-cache"
 import { MemoryStorage } from "."
 
+const meta = { createdAt: 1234, ttl: 1000, isLazy: true }
 describe("MemoryStorage", () => {
     it("Should add cache item correctly", async () => {
         const storage = new MemoryStorage()
         const content = { data: { name: "deep" } }
         const key = "test"
 
-        await storage.setItem(key, content)
+        await storage.setItem(key, { content, meta })
 
-        expect(await storage.getItem(key)).toStrictEqual(content)
+        const result = await storage.getItem(key)
+        expect(result?.content).toBe(content)
     })
 
     it("Should work with a simple string", async () => {
@@ -17,19 +19,22 @@ describe("MemoryStorage", () => {
         const content = "mystring123"
         const key = "key1"
 
-        await storage.setItem(key, content)
+        await storage.setItem(key, { content, meta })
 
-        expect(await storage.getItem(key)).toStrictEqual(content)
+        const result = await storage.getItem(key)
+        expect(result?.content).toStrictEqual(content)
     })
 
     it("Should work with multiple entries", async () => {
         const storage = new MemoryStorage()
 
-        await storage.setItem("k1", "c1")
-        await storage.setItem("k2", "c2")
+        await storage.setItem("k1", { content: "c1", meta })
+        await storage.setItem("k2", { content: "c2", meta })
 
-        expect(await storage.getItem("k1")).toStrictEqual("c1")
-        expect(await storage.getItem("k2")).toStrictEqual("c2")
+        const k1 = await storage.getItem("k1")
+        const k2 = await storage.getItem("k2")
+        expect(k1?.content).toStrictEqual("c1")
+        expect(k2?.content).toStrictEqual("c2")
     })
 
     it("Should work with decorator", async () => {
@@ -43,7 +48,6 @@ describe("MemoryStorage", () => {
         }
 
         const instance = new TestClass()
-
         const users = await instance.getUsers()
 
         expect(origData).toStrictEqual(users)


### PR DESCRIPTION
closes https://github.com/havsar/node-ts-cache/issues/36

to determine a result status, now we're returning some metadata from getItem. in addition this cleans up the behaviour for isLazy. A lazy item returns and gets removed thereafter.