### PR TITLE
feat: let ttl accept milliseconds and null

### DIFF
--- a/packages/core/src/cacheContainer.ts
+++ b/packages/core/src/cacheContainer.ts
@@ -3,8 +3,6 @@ import type { Storage } from "./storage";
 
 const debug = Debug("node-ts-cache");
 
-const DEFAULT_TTL_SECONDS = 60;
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type CachedItem<T = any> = {
   content: T;
@@ -16,12 +14,10 @@ export type CachedItem<T = any> = {
 };
 
 export type CachingOptions = {
-  /** (Default: 60) Number of seconds to expire the cachte item */
-  ttl: number;
+  /** Number of milliseconds to expire the cachte item - defaults to forever */
+  ttl: number | null;
   /** (Default: true) If true, expired cache entries will be deleted on touch and returned anyway. If false, entries will be deleted after the given ttl. */
   isLazy: boolean;
-  /** (Default: false) If true, cache entry has no expiration. */
-  isCachedForever: boolean;
   /** (Default: JSON.stringify combination of className, methodName and call args) */
   calculateKey: (data: {
     /** The class name for the method being decorated */
@@ -67,16 +63,15 @@ export class CacheContainer {
     options?: Partial<CachingOptions>
   ): Promise<void> {
     const finalOptions = {
-      ttl: DEFAULT_TTL_SECONDS,
+      ttl: null,
       isLazy: true,
-      isCachedForever: false,
       ...options,
     };
 
     const meta: CachedItem<typeof content>["meta"] = {
       createdAt: Date.now(),
       isLazy: finalOptions.isLazy,
-      ttl: finalOptions.isCachedForever ? null : finalOptions.ttl * 1000,
+      ttl: finalOptions.ttl,
     };
 
     await this.storage.setItem(key, { meta, content });

--- a/packages/core/src/utils/decoratorTestFactory.ts
+++ b/packages/core/src/utils/decoratorTestFactory.ts
@@ -16,25 +16,25 @@ export const decoratorTestFactory = (storage: Storage) => {
     });
 
     class TestClass1 {
-      @Cache(cache, { ttl: 0.5, isLazy: false })
+      @Cache(cache, { ttl: 500, isLazy: false })
       public getUsersPromise(): Promise<string[]> {
         spy();
         return Promise.resolve(data);
       }
 
-      @Cache(cache, { ttl: 0.5, isLazy: false })
+      @Cache(cache, { ttl: 500, isLazy: false })
       public async getUsersAsync(): Promise<string[]> {
         spy();
         return Promise.resolve(data);
       }
 
-      @Cache(cache, { ttl: 0.5, isLazy: true })
+      @Cache(cache, { ttl: 500, isLazy: true })
       public getUsersPromiseLazy(): Promise<string[]> {
         spy();
         return Promise.resolve(data);
       }
 
-      @Cache(cache, { ttl: 0.5, isLazy: true })
+      @Cache(cache, { ttl: 500, isLazy: true })
       public getUsers(): string[] {
         spy();
         return data;
@@ -42,13 +42,13 @@ export const decoratorTestFactory = (storage: Storage) => {
     }
 
     class TestClass3 {
-      @Cache(cache, { ttl: 1, calculateKey: (data) => data.methodName })
+      @Cache(cache, { ttl: 1000, calculateKey: (data) => data.methodName })
       public getUsers(): string[] {
         spy();
         return data;
       }
 
-      @Cache(cache, { ttl: 1, calculateKey: (data) => data.methodName })
+      @Cache(cache, { ttl: 1000, calculateKey: (data) => data.methodName })
       public getUsersPromise(): Promise<string[]> {
         spy();
         return Promise.resolve(data);
@@ -56,7 +56,7 @@ export const decoratorTestFactory = (storage: Storage) => {
     }
 
     class TestClass4 {
-      @Cache(cache, { ttl: 1, calculateKey: (data) => data.methodName })
+      @Cache(cache, { ttl: 1000, calculateKey: (data) => data.methodName })
       public getUsersPromise(): Promise<string[]> {
         spy();
         return Promise.resolve(data);
@@ -64,7 +64,7 @@ export const decoratorTestFactory = (storage: Storage) => {
     }
 
     class TestClass5 {
-      @Cache(cache, { ttl: 10 })
+      @Cache(cache, { ttl: 10000 })
       public async getUser(name: string) {
         spy();
         if (name == "name1") {

--- a/packages/core/src/utils/storageTestFactory.ts
+++ b/packages/core/src/utils/storageTestFactory.ts
@@ -116,7 +116,7 @@ export const storageTestFactory = (storage: Storage) => {
       const wrappedFn = withCacheFactory(cache)(testingFunction, {
         isLazy: true,
         afterExpired,
-        ttl: 1,
+        ttl: 1000,
       });
 
       const result = await wrappedFn({ a: "wrapped-hello", b: 555 });
@@ -250,7 +250,7 @@ export const storageTestFactory = (storage: Storage) => {
     };
 
     it("should set cache item correctly with isLazy", async () => {
-      await cache.setItem("test", data, { ttl: 10 });
+      await cache.setItem("test", data, { ttl: 10000 });
       const entry = await cache.getItem<ITestType>("test");
 
       expect(entry?.content).toStrictEqual(data);
@@ -263,7 +263,7 @@ export const storageTestFactory = (storage: Storage) => {
     });
 
     it("should return item if cache expired with isLazy and remove it", async () => {
-      await cache.setItem("test", data, { ttl: 0.5, isLazy: true });
+      await cache.setItem("test", data, { ttl: 500, isLazy: true });
       await sleep(750);
       const entry = await cache.getItem<ITestType>("test");
       expect(entry?.content).toStrictEqual(data);
@@ -273,18 +273,17 @@ export const storageTestFactory = (storage: Storage) => {
     });
 
     it("Should not find cache item after ttl with isLazy disabled", async () => {
-      await cache.setItem("test", data, { ttl: 0.5, isLazy: false });
+      await cache.setItem("test", data, { ttl: 500, isLazy: false });
       await sleep(750);
 
       const entry = await cache.getItem<ITestType>("test");
       expect(entry).toStrictEqual(undefined);
     });
 
-    it("Should ignore isLazy and ttl options if isCachedForever", async () => {
+    it("Should ignore isLazy if ttl is null", async () => {
       await cache.setItem("test", data, {
-        ttl: 0.5,
-        isLazy: false,
-        isCachedForever: true,
+        ttl: null,
+        isLazy: true,
       });
       await sleep(750);
 


### PR DESCRIPTION
the current implementation of "isCachedForever" is odd and could be replaced with passing a "null" for the ttl. also having a ttl in seconds to just then convert it to milliseconds is odd. this aligns both.